### PR TITLE
Fix error C4703 on VS 2019 build

### DIFF
--- a/expand.c
+++ b/expand.c
@@ -376,7 +376,7 @@ static int  print_macro_inf(
  * Enabled by '#pragma MCPP debug macro_call' or -K option in STD mode.
  */
 {
-    MACRO_INF *     m_inf;
+    MACRO_INF *     m_inf = NULL;
     int     num;
     int     num_args;   /* Number of actual args (maybe less than expected) */
     int     i;
@@ -473,7 +473,7 @@ static char *   replace(
         /* Number of actual arguments (maybe less than expected)    */
     int     enable_trace_macro;     /* To exclude _Pragma() pseudo macro    */
     int     m_num = 0;              /* 'mac_num' of current macro   */
-    MACRO_INF *     m_inf;          /* Pointer into mac_inf[]       */
+    MACRO_INF *     m_inf = NULL;          /* Pointer into mac_inf[]       */
 
     if (mcpp_debug & EXPAND) {
         dump_a_def( "replace entry", defp, FALSE, TRUE, fp_debug);
@@ -1187,7 +1187,7 @@ static char *     remove_magics(
     mac_n = arg_n = n = 0;
 
     while ((*tp++ = c = get_ch()) != RT_END && file == infile) {
-        char ** loc_tab;
+        char ** loc_tab = NULL;
         int     num, mark, rm, magic;
         size_t  len;
 
@@ -1493,7 +1493,7 @@ static char *   rescan(
     char *  tp = NULL;              /* Temporary pointer into buffer*/
     char *  out_p = out;            /* Current output pointer       */
     FILEINFO *  file;       /* Input sequences stacked on a "file"  */
-    DEFBUF *    inner;              /* Inner macro to replace       */
+    DEFBUF *    inner = NULL;              /* Inner macro to replace       */
     int     c;                      /* First character of token     */
     int     token_type;
     char *  mac_arg_start = NULL;
@@ -1771,8 +1771,8 @@ static int  collect_args(
     int     nargs = 0;                  /* Number of collected args */
     int     var_arg = defp->nargs & VA_ARGS;    /* Variable args    */
     int     more_to_come = FALSE;       /* Next argument is expected*/
-    LOCATION *  locs;           /* Location of args in source file  */
-    LOCATION *  loc;                            /* Current locs     */
+    LOCATION *  locs = NULL;    /* Location of args in source file  */
+    LOCATION *  loc = NULL;                     /* Current locs     */
     MAGIC_SEQ   mgc_prefix;     /* MAC_INF seqs and spaces preceding an arg */
     int     c;
 


### PR DESCRIPTION
The following errors occur when building the library in Visual Studio 2019 (cl):

```
expand.c(410): error C4703: potentially uninitialized local pointer variable 'm_inf' used
expand.c(539): error C4703: potentially uninitialized local pointer variable 'm_inf' used
expand.c(1909): error C4703: potentially uninitialized local pointer variable 'loc' used
expand.c(1909): error C4703: potentially uninitialized local pointer variable 'locs' used
expand.c(1626): error C4703: potentially uninitialized local pointer variable 'inner' used
expand.c(1234): error C4703: potentially uninitialized local pointer variable 'loc_tab' used
```

Initializing the pointers with NULL resolves the error.